### PR TITLE
Add license field

### DIFF
--- a/reVReports/version.py
+++ b/reVReports/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """reVReports version number"""
 
-__version__ = "1.0.14"
+__version__ = "1.0.15"

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     description=DESCRIPTION,
     long_description=README,
     long_description_content_type='text/markdown',
+    license="BSD 3-Clause",
     author="Michael Gleason",
     author_email="mike.gleason@nrel.gov",
     packages=find_packages(),


### PR DESCRIPTION
I guess I was missing a license field in setup.py. A little strange/frustrating since I ran the twine check locally and it passed, so I really don't know why it failed on GitHub.

Anyways, this is still part of getting the repo uploaded to PyPi